### PR TITLE
Handle updated shape names retrieved from external API

### DIFF
--- a/lego/tests/__init__.py
+++ b/lego/tests/__init__.py
@@ -46,6 +46,15 @@ def _mock_generator(set_lego_id):
             "quantity": 3,
             "is_spare": False,
         }
+        yield {
+            "lego_id": "234pr",
+            # shape name for this lego_id differs from db, must be updated
+            "name": "Brick 2 x 4 with studs",
+            "color_name": "Blue",
+            "image_url": "img234prB.jpg",
+            "quantity": 1,
+            "is_spare": False,
+        }
     else:
         raise ValueError("_mock_generator: unexpected test argument")
 

--- a/lego/tests/test_browser_ui.py
+++ b/lego/tests/test_browser_ui.py
@@ -164,6 +164,10 @@ class TestBrowserUI(LiveServerTestCase):
         self.driver.find_element(By.XPATH, "//div[text()='Wheel']")
         self.driver.find_element(By.XPATH, "//div[text()='Black']")
         self.driver.find_element(By.XPATH, "//img[@src='img222k.jpg']")
+        self.driver.find_element(By.XPATH, "//a[text()='234pr']")
+        self.driver.find_element(By.XPATH, "//div[text()='Brick 2 x 4 with studs']")
+        self.driver.find_element(By.XPATH, "//div[text()='Blue']")
+        self.driver.find_element(By.XPATH, "//img[@src='img234prB.jpg']")
 
     def test_add_set_without_suffix(self):
         self.login_test_user()

--- a/lego/tests/test_client_response.py
+++ b/lego/tests/test_client_response.py
@@ -238,6 +238,7 @@ class TestAddSet(TestCase):
             b'.*1x.*333.*Pilot.*src="img333.jpg"'
             b'.*1x.*111.*Jet Engine.*Blue.*src="img111b.jpg"'
             b'.*3x.*222.*Wheel.*Black.*src="img222k.jpg"',
+            b'.*1x.*234pr.*Brick 2 x 4 with studs.*Blue.*src="img234prB.jpg"'
         )
 
     def test_add_set_without_suffix(self):

--- a/lego/views.py
+++ b/lego/views.py
@@ -126,7 +126,7 @@ def add_set(request):
         if item.get("is_spare"):
             logger.info(f"Skipping spare part: {item["name"]}, {item.get("color_name")}")
             continue
-        shape = _log_get_or_create(Shape, lego_id=item["lego_id"], name=item["name"])
+        shape = _get_shape(lego_id=item["lego_id"], name=item["name"])
         color_name = item.get("color_name")
         color = _log_get_or_create(Color, name=color_name) if color_name else None
         part = _log_get_or_create(
@@ -141,6 +141,20 @@ def _log_get_or_create(model, **kwargs):
     if created:
         logger.info(f"Created: {obj!r}")
     return obj
+
+
+def _get_shape(lego_id, name):
+    try:
+        shape = Shape.objects.get(lego_id=lego_id)
+        if shape.name != name:
+            logger.info(f"Outdated: {shape!r}")
+            shape.name = name
+            shape.save()
+            logger.info(f"Updated: {shape!r}")
+    except Shape.DoesNotExist:
+        shape = Shape.objects.create(lego_id=lego_id, name=name)
+        logger.info(f"Created: {shape!r}")
+    return shape
 
 
 login = LoginView.as_view(


### PR DESCRIPTION
Fix an issue where uniqueness constraint would be violated when attempting to create a Shape object with existing lego_id and different name.