### PR TITLE
settings: Update config of static files

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -27,6 +27,7 @@ jobs:
       env:
         DATABASE_URL: "sqlite:///testdb.sqlite3"
         LEGO_SECRET_KEY: ${{ secrets.TEST_LEGO_SECRET_KEY }}
+        LEGO_TEST: true
       run: |
         python manage.py collectstatic --no-input
         python manage.py check

--- a/project/settings.py
+++ b/project/settings.py
@@ -106,9 +106,17 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 
-if not DEBUG:
-    STATIC_ROOT = BASE_DIR / "staticfiles"
-    STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+if not os.getenv("LEGO_TEST"):
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+        "staticfiles": {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        },
+    }
 
 
 # Default primary key field type


### PR DESCRIPTION
- use the same `STATIC_ROOT` in development and production
- replace the deprecated `STATICFILES_STORAGE` setting with `STORAGES["staticfiles"]`
- bypass `whitenoise` storage during tests