### PR TITLE
CI: Update workflow

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         python manage.py collectstatic --no-input
         python manage.py check
-        python manage.py test --parallel --shuffle --durations=10 --verbosity=2 lego
+        python manage.py test --noinput --failfast --shuffle --verbosity=2 --durations=10 --exclude-tag=browser lego

--- a/lego/tests/test_browser_ui.py
+++ b/lego/tests/test_browser_ui.py
@@ -2,7 +2,6 @@ import os
 import shutil
 from pathlib import Path
 from tempfile import mkdtemp
-import unittest
 
 from django.contrib.staticfiles.testing import LiveServerTestCase
 from django.test import tag
@@ -12,7 +11,6 @@ from selenium.webdriver.common.by import By
 from . import test_settings, get_set_info_mock, get_set_parts_mock
 
 
-@unittest.skipIf(os.getenv("CI"), reason="Browser tests not run in CI")
 @tag("browser")
 @test_settings
 class TestBrowserUI(LiveServerTestCase):


### PR DESCRIPTION
- exclude browser tests using the test tag
- remove `parallel` option to see full tracebacks