### PR TITLE
CI: Remove unnecessary database setting

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -67,9 +67,6 @@ DATABASES = {
     ),
 }
 
-if os.getenv("CI"):
-    DATABASES["default"].setdefault("OPTIONS", {})["transaction_mode"] = "EXCLUSIVE"
-
 
 # Password validation
 


### PR DESCRIPTION
`django-tasks` does not require exclusive transactions for SQLite as of version 0.7.0:
https://github.com/RealOrangeOne/django-tasks/releases/tag/0.7.0
