### PR TITLE
Define a context processor to provide common context

### DIFF
--- a/lego/context_processors.py
+++ b/lego/context_processors.py
@@ -1,0 +1,8 @@
+from .forms import SearchForm
+
+
+def common_context(request):
+    return {
+        "website_name": "O&F Lego",
+        "search_form": SearchForm,
+    }

--- a/lego/templates/lego/base.html
+++ b/lego/templates/lego/base.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css" />
   <link rel="stylesheet" type="text/css" href="{% static 'lego/css/styles.css' %}">
   <link rel="shortcut icon" href="{% static 'lego/favicon.png' %}">
-  <title>{{ title }} | {{ site_name }}</title>
+  <title>{{ title }} | {{ website_name }}</title>
 {% block append_head %}
 {% endblock %}
 </head>
@@ -16,7 +16,7 @@
 <div class="container">
 <div class="columns">
 <div class="column">
-  <a href="{% url 'index' %}" id="index_link"><div class="title is-3">{{ site_name }}</div></a>
+  <a href="{% url 'index' %}" id="index_link"><div class="title is-3">{{ website_name }}</div></a>
 </div>
 <div class="column">
   <form action="{% url 'search' %}" method="get">

--- a/lego/templates/lego/login.html
+++ b/lego/templates/lego/login.html
@@ -3,7 +3,7 @@
   {% if user.is_authenticated %}
     You are already logged in
   {% else %}
-    <div class="title is-4">Log in</div>
+    <div class="title is-4">{{ title }}</div>
     <form action="{% url 'login' %}" method="post">{% csrf_token %}
       {{ form }}
       <input type="hidden" name="next" value="{{ request.headers.Referer }}">

--- a/lego/tests/test_client_response.py
+++ b/lego/tests/test_client_response.py
@@ -377,3 +377,16 @@ class TestAuth(TestCase, OrderedPartsMixin):
         self.assertIn("Log in", response.text)
         self.assertNotIn("Add a New Lego Set", response.text)
         self.assertNotIn("Admin Page", response.text)
+
+
+@test_settings
+class TestCommonContext(TestCase, OrderedPartsMixin):
+
+    def test_common_context_rendered(self):
+        response = self.client.get("/lego/")
+        self.assertInHTML("Home | O&F Lego", response.text)
+        self.assertParts(response.text, "Search:", "everywhere")
+
+        response = self.client.get("/lego/login/")
+        self.assertInHTML("O&F Lego", response.text)
+        self.assertParts(response.text, "Search:", "everywhere")

--- a/lego/tests/test_client_response.py
+++ b/lego/tests/test_client_response.py
@@ -388,5 +388,5 @@ class TestCommonContext(TestCase, OrderedPartsMixin):
         self.assertParts(response.text, "Search:", "everywhere")
 
         response = self.client.get("/lego/login/")
-        self.assertInHTML("O&F Lego", response.text)
+        self.assertInHTML("Log in | O&F Lego", response.text)
         self.assertParts(response.text, "Search:", "everywhere")

--- a/lego/views.py
+++ b/lego/views.py
@@ -137,6 +137,7 @@ def add_set(request):
 _login = LoginView.as_view(
     template_name="lego/login.html",
     next_page="/lego/",
+    extra_context={"title": "Log in"},
 )
 
 

--- a/lego/views.py
+++ b/lego/views.py
@@ -12,8 +12,6 @@ from .forms import SearchForm, AddSetForm
 from .models import LegoPart, LegoSet
 from .orm_utils import save_set_with_parts
 
-COMMON_CONTEXT = {"site_name": "O&F Lego", "search_form": SearchForm}
-
 logger = logging.getLogger(__name__)
 
 
@@ -22,7 +20,7 @@ class IndexView(ListView):
     template_name = "lego/index.html"
     paginate_by = 24
     ordering = "-pk"
-    extra_context = COMMON_CONTEXT | {"title": "Home"}
+    extra_context = {"title": "Home"}
 
 
 class SetDetail(DetailView):
@@ -33,7 +31,7 @@ class SetDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        return context | COMMON_CONTEXT | {"title": f"Lego Set {self.object}"}
+        return context | {"title": f"Lego Set {self.object}"}
 
 
 class PartDetail(DetailView):
@@ -48,7 +46,7 @@ class PartDetail(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        return context | COMMON_CONTEXT | {"title": f"Lego Part {self.object}"}
+        return context | {"title": f"Lego Part {self.object}"}
 
 
 def search(request):
@@ -57,7 +55,7 @@ def search(request):
         return render(
             request,
             "lego/search.html",
-            context=COMMON_CONTEXT | {"title": "Search", "search_form": form},
+            context={"title": "Search", "search_form": form},
         )
 
     search_string = form.cleaned_data["q"]
@@ -85,7 +83,7 @@ def search(request):
     return render(
         request,
         "lego/search.html",
-        context=COMMON_CONTEXT | {
+        context={
             "sets": sets,
             "parts": parts,
             "title": f"Search Results for {search_string!r}",
@@ -100,7 +98,7 @@ def add_set(request):
         return render(
             request,
             "lego/add_set.html",
-            context=COMMON_CONTEXT | {
+            context={
                 "add_set_form": AddSetForm,
                 "title": "Add a New Lego Set",
             },
@@ -111,7 +109,7 @@ def add_set(request):
         return render(
             request,
             "lego/add_set.html",
-            context=COMMON_CONTEXT | {
+            context={
                 "add_set_form": form,
                 "title": "Add a New Lego Set",
             },
@@ -139,7 +137,6 @@ def add_set(request):
 _login = LoginView.as_view(
     template_name="lego/login.html",
     next_page="/lego/",
-    extra_context=COMMON_CONTEXT,
 )
 
 

--- a/project/settings.py
+++ b/project/settings.py
@@ -50,6 +50,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "lego.context_processors.common_context",
             ],
         },
     },


### PR DESCRIPTION
Rename `site_name` to `website_name` to avoid collision on the login page.