### PR TITLE
CI: Skip browser tests

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -41,8 +41,7 @@ jobs:
       env:
         DATABASE_URL: "postgresql://test_user:test_password@localhost:5432/lego"
         LEGO_SECRET_KEY: ${{ secrets.TEST_LEGO_SECRET_KEY }}
-        FIREFOX_HEADLESS: 1
       run: |
         python manage.py collectstatic --no-input
         python manage.py check
-        python manage.py test --noinput --failfast --shuffle --verbosity=2 --durations=10 lego
+        python manage.py test --noinput --failfast --shuffle --verbosity=2 --durations=10 --exclude-tag=browser lego


### PR DESCRIPTION
Selenium tests started to fail unexpectedly in GitHub Actions. This change is intended to be temporary.