### PR TITLE
templates: Add link to all colors of a shape

### DIFF
--- a/lego/templates/lego/part_detail.html
+++ b/lego/templates/lego/part_detail.html
@@ -7,6 +7,9 @@
   {% elif legopart.image_url %}<div><figure class="image is-128x128"><img src="{{ legopart.image_url }}"></figure></div>
   {% else %}<div class="ti ti-lego icon-96"></div>
   {% endif %}
+  {% if legopart.color and legopart.shape.num_code %}
+    <div class="subtitle"><a href="{% url 'search' %}?q={{ legopart.shape.num_code }}&mode=id" id="all_colors">All colors</a></div>
+  {% endif %}
   <div class="subtitle">Included in:</div>
   <div class="grid">
   {% for item in legopart.setitem_set.all %}

--- a/lego/tests/test_browser_ui.py
+++ b/lego/tests/test_browser_ui.py
@@ -49,11 +49,19 @@ class TestBrowserUI(LiveServerTestCase):
         # go to part detail
         part_link.click()
         self.assertIn("Lego Part 2345 Brick 2 x 4, Red", self.driver.title)
-        set_link = self.driver.find_element(By.XPATH, "//a[starts-with(@title, '123-1')]")
+        colors_link = self.driver.find_element(By.ID, "all_colors")
 
-        # go back to set detail
+        # go to colors
+        colors_link.click()
+        part_link = self.driver.find_element(By.XPATH, "//a[@title='2345 Brick 2 x 4, White']")
+
+        # go to other part detail
+        part_link.click()
+        set_link = self.driver.find_element(By.XPATH, "//a[starts-with(@title, '111-1')]")
+
+        # go to other set detail
         set_link.click()
-        self.assertIn("Lego Set 123-1 Brick House", self.driver.title)
+        self.assertIn("Lego Set 111-1 Airport", self.driver.title)
         home_link = self.driver.find_element(By.LINK_TEXT, "O&F Lego")
 
         # go back to index page

--- a/lego/tests/test_client_response.py
+++ b/lego/tests/test_client_response.py
@@ -50,6 +50,7 @@ class TestGetResponse(TestCase, OrderedPartsMixin):
             "Included in:",
             "1x in", "123-1 Brick House",
         )
+        self.assertNotIn("All colors", response.text)
 
     def test_part_detail_with_color_id(self):
         response = self.client.get("/lego/part/2345/1/")
@@ -58,6 +59,7 @@ class TestGetResponse(TestCase, OrderedPartsMixin):
         self.assertParts(
             response.text,
             "Lego Part 2345 Brick 2 x 4, Red",
+            "All colors",
             "Included in:",
             "1x in", "111-1 Airport",
         )


### PR DESCRIPTION
Add an `All colors` link to part detail page.