### PR TITLE
images: Save static images as WEBP

### DIFF
--- a/lego/images.py
+++ b/lego/images.py
@@ -31,23 +31,6 @@ def _scaled_image_for_url(url):
     return scaled_img
 
 
-def _suffix_and_params(format):
-    match format:
-        case "JPEG" | "MPO":
-            suffix = "jpg"
-            params = {"quality": 92}
-        case "PNG":
-            suffix = "png"
-            params = {"compress_level": 3}
-        case "WEBP":
-            suffix = "webp"
-            params = {"quality": 85}
-        case _:
-            suffix = None
-            params = {}
-    return suffix, params
-
-
 def _delete_image_url(obj):
     obj.image_url = None
     obj.save()
@@ -76,15 +59,9 @@ def _store_image(model, pk, subdir):
         _delete_image_url(obj)
         return
 
-    suffix, params = _suffix_and_params(image.format)
-    if suffix is None:
-        logger.warning(f"Unexpected image format {image.format!r} for {obj!r}")
-        _delete_image_url(obj)
-        return
-
-    rel_path = Path("lego") / "img" / subdir / f"{obj.pk}.{suffix}"
+    rel_path = Path("lego") / "img" / subdir / f"{obj.pk}.webp"
     logger.info(f"Saving to static: {rel_path}")
-    image.save(STATIC_DIR / rel_path, **params)
+    image.save(STATIC_DIR / rel_path)
 
     obj.image = rel_path
     obj.save()

--- a/lego/tests/test_images.py
+++ b/lego/tests/test_images.py
@@ -23,17 +23,7 @@ class TestStoreImage(TestCase):
         pk = LegoPart.objects.filter(image_url__isnull=False).first().pk
         with (
             patch("lego.images._scaled_image_for_url", side_effect=OSError),
-            patch("lego.images._suffix_and_params") as mock,
-        ):
-            _store_image(LegoPart, pk, "parts")
-
-        mock.assert_not_called()
-
-    def test_skips_unknown_image_format(self):
-        pk = LegoPart.objects.filter(image_url__isnull=False).first().pk
-        with (
-            patch("lego.images.Image.Image", autospec=True, format="TEST") as image,
-            patch("lego.images._scaled_image_for_url", return_value=image),
+            patch("lego.images.Image.Image", autospec=True) as image,
         ):
             _store_image(LegoPart, pk, "parts")
 

--- a/lego/tests/test_logging.py
+++ b/lego/tests/test_logging.py
@@ -90,22 +90,6 @@ class TestStoreImage(TestCase, OrderedPartsMixin):
             "INFO", "Deleted `image_url`: LegoPart",
         )
 
-    def test_unknown_image_format(self):
-        pk = LegoPart.objects.filter(image_url__isnull=False).first().pk
-        with (
-            patch("lego.images.Image.Image", autospec=True, format="TEST") as image,
-            patch("lego.images._scaled_image_for_url", return_value=image),
-            self.assertLogs("lego.images", "INFO") as log_obj,
-        ):
-            _store_image(LegoPart, pk, "parts")
-
-        log_output = "\n".join(log_obj.output)
-        self.assertParts(
-            log_output,
-            "WARNING", "Unexpected image format 'TEST'",
-            "INFO", "Deleted `image_url`: LegoPart",
-        )
-
 
 @test_settings
 class TestAuth(TestCase, OrderedPartsMixin):


### PR DESCRIPTION
Do not check source file format, convert all images to WEBP format.