### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 Django==5.2.6
 django-tasks==0.8.1
-psycopg[binary]==3.2.9
+psycopg[binary]==3.2.10
 requests==2.32.5
 dj-database-url==3.0.1
-whitenoise[brotli]==6.9.0
+whitenoise[brotli]==6.10.0
 gunicorn==23.0.0
 uvicorn==0.35.0
 pillow==11.3.0


### PR DESCRIPTION
- bump `psycopg` from 3.2.9 to 3.2.10
- bump `whitenoise` from 6.9.0 to 6.10.0