### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ Django==6.0.3
 django-tasks==0.12.0
 django-tasks-db==0.12.0
 psycopg[binary]==3.3.3
-requests==2.33.0
+requests==2.33.1
 dj-database-url==3.1.2
 whitenoise[brotli]==6.12.0
 gunicorn==25.3.0
-uvicorn==0.42.0
-pillow==12.1.1
+uvicorn==0.43.0
+pillow==12.2.0
 python-dotenv==1.2.2


### PR DESCRIPTION
- bump pillow from 12.1.1 to 12.2.0
- bump requests from 2.33.0 to 2.33.1
- bump uvicorn from 0.42.0 to 0.43.0