### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==6.0.3
+Django==6.0.4
 django-tasks==0.12.0
 django-tasks-db==0.12.0
 psycopg[binary]==3.3.3
@@ -6,6 +6,6 @@ requests==2.33.1
 dj-database-url==3.1.2
 whitenoise[brotli]==6.12.0
 gunicorn==25.3.0
-uvicorn==0.43.0
+uvicorn==0.44.0
 pillow==12.2.0
 python-dotenv==1.2.2


### PR DESCRIPTION
- bump django from 6.0.3 to 6.0.4
- bump uvicorn from 0.43.0 to 0.44.0