### PR TITLE
views: Fix N+1 problem in index view

### DIFF
--- a/lego/templates/lego/index.html
+++ b/lego/templates/lego/index.html
@@ -4,7 +4,7 @@
 {% block content %}
   <div class="title is-4">Latest Additions</div>
   <div class="grid">
-  {% for set in page_obj %}
+  {% for set in object_list %}
     <div class="box">
       {% if set.image.static_path|is_static_file %}
         <div>

--- a/lego/tests/test_db_operations.py
+++ b/lego/tests/test_db_operations.py
@@ -7,6 +7,10 @@ from lego.tests import test_settings
 class TestNumberOfQueries(TestCase):
     fixtures = ["test_data"]
 
+    def test_index_page(self):
+        with self.assertNumQueries(2):
+            self.client.get("/lego/")
+
     def test_set_detail(self):
         """
         1. select LegoSet + related many-to-one (select_related)

--- a/lego/views.py
+++ b/lego/views.py
@@ -15,11 +15,12 @@ logger = logging.getLogger(__name__)
 
 
 class IndexView(ListView):
-    model = LegoSet
     template_name = "lego/index.html"
     paginate_by = 24
-    ordering = "-pk"
     extra_context = {"title": "Home"}
+
+    def get_queryset(self):
+        return LegoSet.objects.select_related("image").order_by("-pk")
 
 
 class SetDetail(DetailView):


### PR DESCRIPTION
Apply `select_related` to `IndexView` queryset to optimize the number of db queries.