### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-Django==6.0.5
+Django==6.0.6
 django-tasks-db==0.12.0
 psycopg[binary]==3.3.4
 requests==2.34.2
 dj-database-url==3.1.2
 whitenoise[brotli]==6.12.0
 gunicorn==26.0.0
-uvicorn==0.48.0
+uvicorn==0.49.0
 pillow==12.2.0
 python-dotenv==1.2.2


### PR DESCRIPTION
- bump django from 6.0.5 to 6.0.6
- bump uvicorn from 0.48.0 to 0.49.0