### PR TITLE
models: Simplify instance `__repr__`

### DIFF
--- a/lego/models.py
+++ b/lego/models.py
@@ -85,7 +85,7 @@ class LegoPart(models.Model):
         return f"{self.shape}, {self.color}" if self.color else f"{self.shape}"
 
     def __repr__(self):
-        return _repr(self, ("id", "shape_id", "color_id", "image_id"))
+        return _repr(self)
 
 
 class LegoSet(models.Model):
@@ -102,7 +102,7 @@ class LegoSet(models.Model):
         return f"{self.lego_id} {self.name}"
 
     def __repr__(self):
-        return _repr(self, ("id", "lego_id", "name", "image_id"))
+        return _repr(self)
 
 
 class SetItem(models.Model):
@@ -114,12 +114,12 @@ class SetItem(models.Model):
         ordering = ["part__shape__name"]
 
     def __repr__(self):
-        return _repr(self, ("id", "set_id", "part_id", "quantity"))
+        return _repr(self)
 
 
 def _repr(instance, field_names=None):
     if field_names is None:
-        field_names = (field.name for field in instance._meta.fields)
+        field_names = (field.attname for field in instance._meta.fields)
 
     fields_repr = ", ".join(
         f"{field_name}={getattr(instance, field_name)!r}"

--- a/lego/models.py
+++ b/lego/models.py
@@ -2,14 +2,6 @@ from django.db import models
 from django.urls import reverse
 
 
-def _instance_repr(self):
-    fields_repr = ", ".join(
-        f"{field.name}={getattr(self, field.name)!r}"
-        for field in self._meta.fields
-    )
-    return f"{self._meta.object_name}({fields_repr})"
-
-
 class NumericPrefix(models.Func):
     function = "substring"
     template = "%(function)s(%(expressions)s from '^\\d+')"
@@ -33,7 +25,8 @@ class Shape(models.Model):
     def __str__(self):
         return f"{self.lego_id} {self.name}"
 
-    __repr__ = _instance_repr
+    def __repr__(self):
+        return _repr(self)
 
 
 class Color(models.Model):
@@ -42,7 +35,8 @@ class Color(models.Model):
     def __str__(self):
         return self.name
 
-    __repr__ = _instance_repr
+    def __repr__(self):
+        return _repr(self)
 
 
 class Image(models.Model):
@@ -65,7 +59,8 @@ class Image(models.Model):
     def __str__(self):
         return self.static_path or self.origin_url
 
-    __repr__ = _instance_repr
+    def __repr__(self):
+        return _repr(self)
 
 
 class LegoPart(models.Model):
@@ -89,7 +84,8 @@ class LegoPart(models.Model):
     def __str__(self):
         return f"{self.shape}, {self.color}" if self.color else f"{self.shape}"
 
-    __repr__ = _instance_repr
+    def __repr__(self):
+        return _repr(self, ("id", "shape_id", "color_id", "image_id"))
 
 
 class LegoSet(models.Model):
@@ -105,7 +101,8 @@ class LegoSet(models.Model):
     def __str__(self):
         return f"{self.lego_id} {self.name}"
 
-    __repr__ = _instance_repr
+    def __repr__(self):
+        return _repr(self, ("id", "lego_id", "name", "image_id"))
 
 
 class SetItem(models.Model):
@@ -115,3 +112,17 @@ class SetItem(models.Model):
 
     class Meta:
         ordering = ["part__shape__name"]
+
+    def __repr__(self):
+        return _repr(self, ("id", "set_id", "part_id", "quantity"))
+
+
+def _repr(instance, field_names=None):
+    if field_names is None:
+        field_names = (field.name for field in instance._meta.fields)
+
+    fields_repr = ", ".join(
+        f"{field_name}={getattr(instance, field_name)!r}"
+        for field_name in field_names
+    )
+    return f"{instance._meta.object_name}({fields_repr})"


### PR DESCRIPTION
Show only foreign keys of related objects instead of including their own `__repr__`.
