### PR TITLE
tests: Skip creating static root for tests

### DIFF
--- a/lego/__init__.py
+++ b/lego/__init__.py
@@ -1,5 +1,4 @@
 from django.conf import settings
 
 APP_DIR = settings.BASE_DIR / "lego"
-STATIC_DIR = APP_DIR / "static"
 TESTS_DIR = APP_DIR / "tests"

--- a/lego/tests/__init__.py
+++ b/lego/tests/__init__.py
@@ -10,17 +10,13 @@ from django.test import override_settings
 from PIL import Image, ImageDraw, ImageFont
 from requests import HTTPError
 
-from lego import STATIC_DIR, TESTS_DIR
+from lego import TESTS_DIR
 
 TESTS_MEDIA_ROOT = TESTS_DIR / "testmedia"
 TESTS_MEDIA_ROOT.mkdir(parents=True, exist_ok=True)
 
-TESTS_STATIC_ROOT = TESTS_DIR / "teststatic"
-TESTS_STATIC_ROOT.mkdir(parents=True, exist_ok=True)
-
 test_settings = override_settings(
     MEDIA_ROOT=TESTS_MEDIA_ROOT,
-    STATIC_ROOT=TESTS_STATIC_ROOT,
     STORAGES={
         "default": {
             "BACKEND": "django.core.files.storage.FileSystemStorage",
@@ -280,7 +276,6 @@ def _generate_image(pk, size, font):
 
 def prepare_assets():
     default_storage = storages["default"]
-    static_storage = storages["staticfiles"]
 
     # generate images
     font = ImageFont.load_default(size=28)
@@ -293,12 +288,4 @@ def prepare_assets():
         image = _generate_image(pk, size, font)
         default_storage.save(f"lego/img/{subdir}/test{pk:04d}.webp", image)
 
-    # copy existing asset
-    rel_path = "lego/css/styles.css"
-    with (STATIC_DIR / rel_path).open("rb") as f:
-        static_storage.save(rel_path, f)
-
-    return (
-        Path(default_storage.location) / "lego",
-        Path(static_storage.location) / "lego",
-    )
+    return Path(default_storage.location) / "lego"

--- a/lego/tests/test_browser_ui.py
+++ b/lego/tests/test_browser_ui.py
@@ -2,7 +2,8 @@ import os
 import shutil
 from tempfile import mkdtemp
 
-from django.test import LiveServerTestCase, tag
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.test import tag
 from selenium.webdriver import Firefox
 from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options
@@ -20,7 +21,7 @@ from . import (
 
 @tag("browser")
 @test_settings
-class TestBrowserUI(LiveServerTestCase):
+class TestBrowserUI(StaticLiveServerTestCase):
     fixtures = ["test_data", "test_user"]
 
     @classmethod
@@ -29,9 +30,8 @@ class TestBrowserUI(LiveServerTestCase):
         os.environ["TMPDIR"] = cls.temp_dir = mkdtemp(dir=TESTS_DIR)
         cls.addClassCleanup(shutil.rmtree, cls.temp_dir)
 
-        media_dir, static_dir = prepare_assets()
+        media_dir = prepare_assets()
         cls.addClassCleanup(shutil.rmtree, media_dir)
-        cls.addClassCleanup(shutil.rmtree, static_dir)
 
         options = Options()
         if not os.getenv("LEGO_TEST_FIREFOX_GUI"):

--- a/lego/tests/test_client_response.py
+++ b/lego/tests/test_client_response.py
@@ -248,9 +248,8 @@ class TestImageUrls(TestCase, OrderedPartsMixin):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        media_dir, static_dir = prepare_assets()
+        media_dir = prepare_assets()
         cls.addClassCleanup(shutil.rmtree, media_dir)
-        cls.addClassCleanup(shutil.rmtree, static_dir)
 
     def test_set_image_urls(self):
         response = self.client.get("/lego/")


### PR DESCRIPTION
Rely on `StaticLiveServerTestCase` in GUI tests.